### PR TITLE
Rootless deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ application/**/*.html
 **/charts/*.tgz
 # Generated charts
 chart/**.tgz
+# Final Chart.yaml
+chart/**/Chart.yaml
 
 ### VisualStudioCode ###
 .vscode/*

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -15,6 +15,9 @@ LABEL org.opencontainers.image.url "https://github.com/Icikowski/GPTS"
 LABEL org.opencontainers.image.source "https://github.com/Icikowski/GPTS"
 LABEL org.opencontainers.image.licenses "GPL-3.0-or-later"
 RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+RUN adduser app -u 1000 -h /app -S -D
+WORKDIR /app/
 COPY --from=builder /app/gpts .
+RUN chmod a+x gpts
+USER 1000
 CMD ["./gpts"] 

--- a/application/Makefile
+++ b/application/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean build test coverage image
+.PHONY: clean build test coverage image chart
 .SILENT: ${.PHONY}
 
 GO_TEST := go test ./... -race -p 1
@@ -7,7 +7,7 @@ all: build
 
 clean:
 ifeq ($(OS), Windows_NT)
-	del /f /s /q *.out *.html gpts gpts.exe
+	del /f /q *.out *.html gpts gpts.exe
 else
 	rm -f *.out *.html gpts gpts.exe
 endif
@@ -26,5 +26,21 @@ coverage: clean
 	${GO_TEST} -v -covermode atomic -coverprofile cover.out
 	go tool cover -html cover.out -o cover.html
 
+
+# COMMANDS FOR LOCAL DEVELOPMENT ONLY
+
 image: clean
 	docker build . -t ghcr.io/icikowski/gpts:$(shell git rev-parse --short HEAD)
+
+chart: clean
+ifeq ($(OS), Windows_NT)
+	type ..\chart\gpts\Chart.template | sed "/^version/! s/\[\[GPTS_VERSION\]\]/$(shell git rev-parse --short HEAD)/" | sed "s/\[\[GPTS_VERSION\]\]/$(shell git describe --abbrev=0 | sed "s/v//")-dev/" >..\chart\gpts\Chart.yaml
+else
+	cat ../chart/gpts/Chart.template | sed "/^version/! s/\[\[GPTS_VERSION\]\]/$(shell git rev-parse --short HEAD)/" | sed "s/\[\[GPTS_VERSION\]\]/$(shell git describe --abbrev=0 | sed "s/v//")-dev/" >../chart/gpts/Chart.yaml
+endif
+	(cd ../chart && helm package gpts)
+ifeq ($(OS), Windows_NT)
+	del /f /q ..\chart\gpts\Chart.yaml
+else
+	rm -f ../chart/gpts/Chart.yaml
+endif

--- a/application/common/env.go
+++ b/application/common/env.go
@@ -14,8 +14,8 @@ var (
 	// ServerPort determines the port number on which service will be running (defaults to 80)
 	ServerPort = getFromEnvironment("GPTS_SERVER_PORT", "80")
 
-	// HealthcheckPort determines the port number on which liveness & readiness endpoints will be running (defaults to 8000)
-	HealthcheckPort = getFromEnvironment("GPTS_HEALTHCHECK_PORT", "8000")
+	// HealthcheckPort determines the port number on which liveness & readiness endpoints will be running (defaults to 8081)
+	HealthcheckPort = getFromEnvironment("GPTS_HEALTHCHECK_PORT", "8081")
 
 	// DefaultConfigOnStartup determines if default config should be loaded when application starts
 	DefaultConfigOnStartup = getFromEnvironment("GPTS_DEFAULT_CONFIG_ON_STARTUP", "false")

--- a/chart/gpts/templates/deployment.yaml
+++ b/chart/gpts/templates/deployment.yaml
@@ -31,23 +31,23 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: GPTS_SERVER_PORT
-              value: {{ .Values.gpts.servicePort | default 80 | quote }}
+              value: {{ .Values.gpts.servicePort | default 8080 | quote }}
             - name: GPTS_HEALTHCHECK_PORT
-              value: {{ .Values.gpts.healthcheckPort | default 8000 | quote }}
+              value: {{ .Values.gpts.healthcheckPort | default 8081 | quote }}
             - name: GPTS_DEFAULT_CONFIG_ON_STARTUP
               value: {{ .Values.gpts.defaultConfigOnStartup | quote }}
           ports:
             - name: http
-              containerPort: {{ .Values.gpts.servicePort | default 80 }}
+              containerPort: {{ .Values.gpts.servicePort | default 8080 }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /live
-              port: {{ .Values.gpts.healthcheckPort | default 8000 }}
+              port: {{ .Values.gpts.healthcheckPort | default 8081 }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.gpts.healthcheckPort | default 8000 }}
+              port: {{ .Values.gpts.healthcheckPort | default 8081 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/gpts/templates/service.yaml
+++ b/chart/gpts/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.gpts.servicePort | default 80 }}
+      targetPort: {{ .Values.gpts.servicePort | default 8080 }}
       protocol: TCP
       name: http
   selector:

--- a/chart/gpts/values.yaml
+++ b/chart/gpts/values.yaml
@@ -9,8 +9,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 gpts:
-  servicePort: 80
-  healthcheckPort: 8000
+  servicePort: 8080
+  healthcheckPort: 8081
   defaultConfigOnStartup: true
 
 service:

--- a/chart/gpts/values.yaml
+++ b/chart/gpts/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 gpts:
   servicePort: 8080
   healthcheckPort: 8081
-  defaultConfigOnStartup: true
+  defaultConfigOnStartup: false
 
 service:
   type: ClusterIP


### PR DESCRIPTION
This pull request contains changes related to security. Instead of running `gpts` as root in generated image, new user `app` is being introduced and used to launch the application. Additionaly, the `gpts` chart is now using port `8080` for service by default (was `80`) and port `8081` for healthchecks (was `8000`).